### PR TITLE
Pin Kombu 3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ future==0.14.3
 gunicorn==19.3.0
 httplib2==0.9.1
 icalendar==3.9.0
-kombu
+kombu~=3.0
 mercurial==3.4.1
 oauth2client==1.4.11
 pyasn1==0.1.7


### PR DESCRIPTION
Kombu 4.0.0 is not compatible with the version of celery frozen in requirements

      File "/opt/openduty/env/local/lib/python2.7/site-packages/celery/five.py", line 153, in <module>
        from kombu.utils.compat import OrderedDict  # noqa
    ImportError: cannot import name OrderedDict